### PR TITLE
User registration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,14 +7,14 @@ dependencies = [
  "diesel 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel_codegen 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "r2d2 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2-diesel 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket_codegen 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket_contrib 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tera 0.10.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -33,25 +33,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "backtrace"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.53 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -90,6 +90,11 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cc"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,7 +105,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -211,17 +216,17 @@ name = "error-chain"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "futures"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "gcc"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -273,13 +278,13 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "itoa"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -303,7 +308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -338,7 +343,7 @@ name = "memchr"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -386,12 +391,12 @@ name = "num_cpus"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ordermap"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -429,7 +434,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "r2d2"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -443,7 +448,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "diesel 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "r2d2 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -451,7 +456,7 @@ name = "rand"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -469,9 +474,9 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -503,9 +508,9 @@ name = "ring"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.53 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -522,16 +527,16 @@ dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ordermap 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordermap 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "pear 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "pear_codegen 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "state 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "state 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "yansi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yansi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -542,7 +547,7 @@ dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "yansi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yansi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -553,8 +558,8 @@ dependencies = [
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tera 0.10.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -563,8 +568,8 @@ name = "rust-crypto"
 version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.53 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -600,22 +605,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.11"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.11"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive_internals 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_internals 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -624,13 +629,13 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -648,7 +653,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "state"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -681,8 +686,8 @@ dependencies = [
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "slug 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -702,7 +707,7 @@ version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -712,7 +717,7 @@ name = "toml"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -811,19 +816,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "yansi"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
 "checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
-"checksum backtrace 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "72f9b4182546f4b04ebc4ab7f84948953a118bd6021a1b6a6c909e3e94f6be76"
-"checksum backtrace-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "afccc5772ba333abccdf60d55200fa3406f8c59dcf54d5f7998c9107d3799c7c"
+"checksum backtrace 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "99f2ce94e22b8e664d95c57fff45b98a966c2252b60691d0b7aeeccd88d70983"
+"checksum backtrace-sys 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "c63ea141ef8fdb10409d0f5daf30ac51f84ef43bff66f16627773d2a292cd189"
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
 "checksum bcrypt 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "feed84d558481ece6e7b867df7b9d42c17c6b14220a045ee545382f4386987a9"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
+"checksum cc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7db2f146208d7e0fbee761b09cd65a7f51ccc38705d4e7262dad4d73b12a76b1"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
 "checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
@@ -839,19 +845,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18785c1ba806c258137c937e44ada9ee7e69a37e3c72077542cd2f069d78562a"
 "checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
-"checksum futures 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a82bdc62350ca9d7974c760e9665102fc9d740992a528c2254aa930e53b783c4"
-"checksum gcc 0.3.53 (registry+https://github.com/rust-lang/crates.io-index)" = "e8310f7e9c890398b0e80e301c4f474e9918d2b27fca8f48486ca775fa9ffc5a"
+"checksum futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "05a23db7bd162d4e8265968602930c476f688f0c180b44bdaf55e0cb2c687558"
+"checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "af2f2dd97457e8fb1ae7c5a420db346af389926e36f43768b96f101546b04a07"
 "checksum humansize 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "92d211e6e70b05749dce515b47684f29a3c8c38bbbb21c50b30aff9eca1b0bd3"
 "checksum hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)" = "368cb56b2740ebf4230520e2b90ebb0461e69034d85d1945febd9b3971426db2"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum isatty 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fa500db770a99afe2a0f2229be2a3d09c7ed9d7e4e8440bf71253141994e240f"
-"checksum itoa 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ac17257442c2ed77dbc9fd555cf83c58b0c7f7d0e8f2ae08c0ac05c72842e1f6"
+"checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
-"checksum libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)" = "2370ca07ec338939e356443dac2296f581453c35fe1e3a3ed06023c49435f915"
+"checksum libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "d1419b2939a0bc44b77feb34661583c7546b532b192feab36249ab584b86856c"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
 "checksum magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf0336886480e671965f794bc9b6fce88503563013d1bfb7a502c81fe3ac527"
 "checksum magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40d014c7011ac470ae28e2f76a02bfea4a8480f73e701353b49ad7a8d75f4699"
@@ -863,14 +869,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "7485fcc84f85b4ecd0ea527b14189281cf27d60e583ae65ebc9c088b13dffe01"
 "checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
 "checksum num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aec53c34f2d0247c5ca5d32cca1478762f301740468ee9ee6dcb7a0dd7a0c584"
-"checksum ordermap 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e2df2a1933286f9d5f370ce42c3056a426845c5491b42ebcab900715bf2c5e"
+"checksum ordermap 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4b46e558656ea66647985c3de0a8ad0cb5f01cba8a4eaff39ae27de3aeda57"
 "checksum pear 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "87dd0e084e2c18b047658e40f89b856dfc23104011fd43f9369e873d03b7f15b"
 "checksum pear_codegen 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0455b67d07b3aa40a552256059f11eb8db3a848cbec81bae3e3cb366e6e74e24"
 "checksum percent-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de154f638187706bde41d9b4738748933d64e6b37bdbffc0b47a97d16a6ae356"
 "checksum pest 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2e823a5967bb4cdc6d3e46f47baaf4ecfeae44413a642b74ad44e59e49c7f6"
 "checksum pq-sys 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4dfb5e575ef93a1b7b2a381d47ba7c5d4e4f73bff37cee932195de769aad9a54"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
-"checksum r2d2 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6c665a538b218e1620093be6643b375d3321837bfc1b30aa18757b7c6546d2ca"
+"checksum r2d2 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2c8284508b38df440f8f3527395e23c4780b22f74226b270daf58fee38e4bcce"
 "checksum r2d2-diesel 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f6b921696a6c45991296d21b52ed973b9fb56f6c47524fda1f99458c2d6c0478"
 "checksum rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "eb250fd207a4729c976794d03db689c9be1d634ab5a1c9da9492a13d8fecbcdf"
 "checksum rayon 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a77c51c07654ddd93f6cb543c7a849863b03abc7e82591afda6dc8ad4ac3ac4a"
@@ -888,13 +894,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum scheduled-thread-pool 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d9fbe48ead32343b76f544c85953bf260ed39219a8bbbb62cd85f6a00f9644f"
 "checksum scopeguard 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c79eb2c3ac4bc2507cda80e7f3ac5b88bd8eae4c0914d5663e6a8933994be918"
-"checksum serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f7726f29ddf9731b17ff113c461e362c381d9d69433f79de4f3dd572488823e9"
-"checksum serde_derive 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cf823e706be268e73e7747b147aa31c8f633ab4ba31f115efb57e5047c3a76dd"
-"checksum serde_derive_internals 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37aee4e0da52d801acfbc0cc219eb1eda7142112339726e427926a6f6ee65d3a"
-"checksum serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "48b04779552e92037212c3615370f6bd57a40ebba7f20e554ff9f55e41a69a7b"
+"checksum serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "6a7046c9d4c6c522d10b2d098f9bebe2bef227e0e74044d8c1bfcf6b476af799"
+"checksum serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "1afcaae083fd1c46952a315062326bc9957f182358eb7da03b57ef1c688f7aa9"
+"checksum serde_derive_internals 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd381f6d01a6616cdba8530492d453b7761b456ba974e98768a18cad2cd76f58"
+"checksum serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d243424e06f9f9c39e3cd36147470fd340db785825e367625f79298a6ac6b7ac"
 "checksum slug 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f5ff4b43cb07b86c5f9236c92714a22cdf9e5a27a7d85e398e2c9403328cb8"
 "checksum smallvec 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8fcd03faf178110ab0334d74ca9631d77f94c8c11cc77fcb59538abf0025695d"
-"checksum state 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3205ddf193c68751abcb17262a430c4c32f0d4cdc6b7f7c8915db442b9579012"
+"checksum state 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "acc74e29126a281afcfd8dfa0ae83f1720a1adf5fc99524898e45ca440a73919"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum tera 0.10.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d706c3bec8103f346fc7b8a3887a2ff4195cf704bdbc6307069f32ea8a2b3af5"
@@ -917,4 +923,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
-"checksum yansi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8200521fa88cba2d4ec8d7500616a284ae8bd92d492a309773478a870660573a"
+"checksum yansi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a503e4eea629f145a693c8ed1eddba88b3b9de5171c6ebd0e2820cf82d38f934"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ dependencies = [
  "diesel 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel_codegen 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fake 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2-diesel 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -217,6 +218,14 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fake"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -845,6 +854,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum either 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18785c1ba806c258137c937e44ada9ee7e69a37e3c72077542cd2f069d78562a"
 "checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
+"checksum fake 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "21b26a5b0f06eca011b4c7dbcafe776e4e1506643fcf3bc8dd8bb8fd3f72d9a9"
 "checksum futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "05a23db7bd162d4e8265968602930c476f688f0c180b44bdaf55e0cb2c687558"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,12 @@ version = "0.1.0"
 authors = ["Ryan B <notryanb@gmail.com>"]
 
 [[bin]]
-name = "blog_demo"
+name = "main"
 path = "src/bin/main.rs"
+
+[[bin]]
+name = "seed"
+path = "src/bin/seed.rs"
 
 [lib]
 name = "bloglib"
@@ -28,6 +32,7 @@ diesel = { version = "0.16", features = ["chrono", "postgres"] }
 diesel_codegen = { version = "*", features = ["postgres"] }
 r2d2 = "*"
 r2d2-diesel = "*"
+fake = "*"
 
 # SYS
 dotenv = "0.10"

--- a/migrations/20170920192641_add_foreign_keys/down.sql
+++ b/migrations/20170920192641_add_foreign_keys/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE posts DROP CONSTRAINT posts_user_id_fkey;

--- a/migrations/20170920192641_add_foreign_keys/up.sql
+++ b/migrations/20170920192641_add_foreign_keys/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE posts ADD CONSTRAINT posts_user_id_fkey FOREIGN KEY (user_id) REFERENCES users;

--- a/src/auth/forms.rs
+++ b/src/auth/forms.rs
@@ -3,3 +3,13 @@ pub struct LoginForm {
     pub email: String,
     pub password: String,
 }
+
+#[derive(Debug, FromForm, Serialize)]
+pub struct RegisterForm {
+    pub first_name: String,
+    pub last_name: String,
+    pub email: String,
+    pub password: String,
+    pub password_confirm: String,
+}
+

--- a/src/auth/forms.rs
+++ b/src/auth/forms.rs
@@ -1,5 +1,5 @@
-use rocket::request::FromFormValue;
 use rocket::http::RawStr;
+use rocket::request::FromFormValue;
 
 #[derive(Debug, FromForm, Serialize)]
 pub struct LoginForm {
@@ -8,6 +8,9 @@ pub struct LoginForm {
 }
 
 pub struct UserField(pub String);
+pub struct FieldPresenceError<'a> { 
+    pub msg: &'a str 
+}
 
 impl<'v> FromFormValue<'v> for UserField {
     type Error = &'v RawStr;
@@ -29,5 +32,20 @@ pub struct RegisterForm {
     pub email: Option<UserField>,
     pub password: Option<UserField>,
     pub password_confirm: Option<UserField>,
+}
+
+impl RegisterForm {
+    pub fn validate_fields_presence(&self) -> Result<&Self, FieldPresenceError> {
+        if self.first_name.is_some() &&
+            self.last_name.is_some() &&
+            self.email.is_some() &&
+            self.password.is_some() &&
+            self.password_confirm.is_some()
+            {
+                return Ok(self);
+            }
+
+        Err(FieldPresenceError { msg: "All fields must be filled out" })
+    }
 }
 

--- a/src/auth/forms.rs
+++ b/src/auth/forms.rs
@@ -9,14 +9,13 @@ pub struct LoginForm {
 
 pub struct UserField(pub String);
 pub struct FieldPresenceError<'a> { 
-    pub msg: &'a str 
+    pub msg: &'a str,
 }
 
 impl<'v> FromFormValue<'v> for UserField {
     type Error = &'v RawStr;
 
     fn from_form_value(form_value: &'v RawStr) -> Result<UserField, &'v RawStr> {
-        println!("THE VALUE COMING THROUGH: |{}|", &form_value);
         match form_value.percent_decode() {
             Ok(ref val) if val.is_empty() => Err(form_value),
             Ok(ref val) => Ok(UserField(val.to_string())),

--- a/src/auth/forms.rs
+++ b/src/auth/forms.rs
@@ -19,7 +19,7 @@ impl<'v> FromFormValue<'v> for UserField {
         match form_value.percent_decode() {
             Ok(ref val) if val.is_empty() => Err(form_value),
             Ok(ref val) => Ok(UserField(val.to_string())),
-            Err(ref val) => Err(form_value)
+            Err(_val) => Err(form_value)
         }
     }
 }

--- a/src/auth/forms.rs
+++ b/src/auth/forms.rs
@@ -1,15 +1,33 @@
+use rocket::request::FromFormValue;
+use rocket::http::RawStr;
+
 #[derive(Debug, FromForm, Serialize)]
 pub struct LoginForm {
     pub email: String,
     pub password: String,
 }
 
-#[derive(Debug, FromForm, Serialize)]
+pub struct UserField(pub String);
+
+impl<'v> FromFormValue<'v> for UserField {
+    type Error = &'v RawStr;
+
+    fn from_form_value(form_value: &'v RawStr) -> Result<UserField, &'v RawStr> {
+        println!("THE VALUE COMING THROUGH: |{}|", &form_value);
+        match form_value.percent_decode() {
+            Ok(ref val) if val.is_empty() => Err(form_value),
+            Ok(ref val) => Ok(UserField(val.to_string())),
+            Err(ref val) => Err(form_value)
+        }
+    }
+}
+
+#[derive(FromForm)]
 pub struct RegisterForm {
-    pub first_name: String,
-    pub last_name: String,
-    pub email: String,
-    pub password: String,
-    pub password_confirm: String,
+    pub first_name: Option<UserField>,
+    pub last_name: Option<UserField>,
+    pub email: Option<UserField>,
+    pub password: Option<UserField>,
+    pub password_confirm: Option<UserField>,
 }
 

--- a/src/auth/forms.rs
+++ b/src/auth/forms.rs
@@ -26,6 +26,7 @@ impl<'v> FromFormValue<'v> for UserField {
 
 #[derive(FromForm)]
 pub struct RegisterForm {
+    pub id: Option<i32>,
     pub first_name: Option<UserField>,
     pub last_name: Option<UserField>,
     pub email: Option<UserField>,
@@ -47,4 +48,3 @@ impl RegisterForm {
         Err(FieldPresenceError { msg: "All fields must be filled out" })
     }
 }
-

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -86,7 +86,7 @@ fn authenticate(
 }
 
 #[get("/logout")]
-fn logout(user: AuthenticatedUser, mut cookies: Cookies) -> Redirect {
+fn logout(_user: AuthenticatedUser, mut cookies: Cookies) -> Redirect {
     cookies.remove_private(Cookie::named("sessions_auth"));
     Redirect::to("/")
 }
@@ -124,14 +124,10 @@ fn register(
 
     // STEPS
     // 1 - Validate presence of all fields
-   
-    // Validation should return Result<FormType>
-    // see if we can chain the logic right on to execute the redirect
-    // or unwrap into the var
 
-    let form = match form.get().validate_fields_presence().as_ref() {
-        Ok(ref val) => val,
-        Err(e) => Err(Flash::error(Redirect::to("/auth/register"), e.msg))
+    let form = match form.get().validate_fields_presence() {
+        Ok(val) => val,
+        Err(e) => return Err(Flash::error(Redirect::to("/auth/register"), e.msg))
     };
     
     // 2 - Validate no other User with that email

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -44,7 +44,7 @@ fn login(user: AnonymousUser, flash: Option<FlashMessage>) -> Template {
 
 #[post("/login", data = "<form>")]
 fn authenticate(
-    user: AnonymousUser,
+    _user: AnonymousUser,
     form: Form<LoginForm>,
     mut cookies: Cookies,
     conn: DbConn,

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -115,6 +115,7 @@ fn register(
     form: Form<RegisterForm>,
     conn: DbConn
 ) -> Result<Redirect, Flash<Redirect>> {
+    use super::schema::users::dsl::*;
     use schema::users;
 
     let mut context = Context::new();
@@ -127,7 +128,13 @@ fn register(
 
     // 2 - Validate no other User with that email
 
-    // let found_user = users.filter(email.eq(&form.email)
+    let found_user = users.filter(email.eq(&form.email))
+        .get_results::<User>(&*conn)
+        .expect("Error loading users");
+
+    if found_user.len() > 0 {
+        return Err(Flash::error(Redirect::to("/auth/register"), "Email already taken"))
+    }
 
     // 3 - Validate PW == PW_CONFIRM
     
@@ -143,7 +150,7 @@ fn register(
     };
 
     // 5 - Insert Email & Username into DB
-    
+
     let new_user = NewUser {
         first_name: &form.first_name,
         last_name: &form.last_name,

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -108,5 +108,5 @@ fn register(user: AnonymousUser, flash: Option<FlashMessage>) -> Template {
 }
 
 pub fn routes() -> Vec<rocket::Route> {
-    routes![authenticate, login, logout]
+    routes![authenticate, login, logout, register]
 }

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -17,7 +17,7 @@ mod forms;
 pub mod models;
 
 #[derive(Serialize)]
-struct InvalidCredentialsMessage<'a> {
+struct InvalidFormMessage<'a> {
     name: &'a str,
     msg: &'a str
 }
@@ -29,7 +29,7 @@ fn login(user: AnonymousUser, flash: Option<FlashMessage>) -> Template {
 
     if flash.is_some() {
         let flash_val = flash.unwrap();
-        let message = InvalidCredentialsMessage {
+        let message = InvalidFormMessage {
             name: &flash_val.name(),
             msg: &flash_val.msg()
         };
@@ -87,6 +87,24 @@ fn authenticate(
 fn logout(user: AuthenticatedUser, mut cookies: Cookies) -> Redirect {
     cookies.remove_private(Cookie::named("sessions_auth"));
     Redirect::to("/")
+}
+
+#[get("/register")]
+fn register(user: AnonymousUser, flash: Option<FlashMessage>) -> Template {
+    let mut context = Context::new();
+    context.add("user", &user);
+
+    if flash.is_some() {
+        let flash_val = flash.unwrap();
+        let message = InvalidFormMessage {
+            name: &flash_val.name(),
+            msg: &flash_val.msg()
+        };
+
+        context.add("flash", &message);
+    }
+
+    Template::render("auth/register", &context)
 }
 
 pub fn routes() -> Vec<rocket::Route> {

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -109,18 +109,6 @@ fn signup(user: AnonymousUser, flash: Option<FlashMessage>) -> Template {
     Template::render("auth/register", &context)
 }
 
-fn validate_presence(form: &RegisterForm) -> bool {
-   if form.first_name.is_none() || 
-        form.last_name.is_none() ||
-        form.email.is_none() ||
-        form.password.is_none() ||
-        form.password_confirm.is_none() 
-    { 
-        return false; 
-    }
-   true
-}
-
 #[post("/register", data = "<form>")]
 fn register(
     user: AnonymousUser,
@@ -135,13 +123,16 @@ fn register(
     
 
     // STEPS
-    // 1 - Validate presence of all fields (first/last_name, email, pw)
-    
-    let form = form.get();
-    if validate_presence(form) {
-    } else {
-        return Err(Flash::error(Redirect::to("/auth/register"), "All fields must be completed"))
-    }
+    // 1 - Validate presence of all fields
+   
+    // Validation should return Result<FormType>
+    // see if we can chain the logic right on to execute the redirect
+    // or unwrap into the var
+
+    let form = match form.get().validate_fields_presence().as_ref() {
+        Ok(ref val) => val,
+        Err(e) => Err(Flash::error(Redirect::to("/auth/register"), e.msg))
+    };
     
     // 2 - Validate no other User with that email
 

--- a/src/auth/models.rs
+++ b/src/auth/models.rs
@@ -30,6 +30,7 @@ pub struct NewUser<'a> {
     pub first_name: &'a str,
     pub last_name: &'a str,
     pub email: &'a str,
+    pub password: &'a str,
 }
 
 #[derive(AsChangeset)]

--- a/src/auth/models.rs
+++ b/src/auth/models.rs
@@ -52,6 +52,7 @@ pub struct UpdateUser<'a> {
     pub first_name: &'a str,
     pub last_name: &'a str,
     pub email: &'a str,
+    pub password: &'a str,
 }
 
 impl ser::Serialize for User {

--- a/src/auth/models.rs
+++ b/src/auth/models.rs
@@ -24,6 +24,7 @@ pub struct User {
     #[serde(skip_serializing, skip_deserializing)] pub password: String,
 }
 
+// TODO: derive(FromForm) so we don't need duplicate form structs
 #[derive(Insertable)]
 #[table_name = "users"]
 pub struct NewUser<'a> {
@@ -33,6 +34,10 @@ pub struct NewUser<'a> {
     pub password: &'a str,
 }
 
+
+// TODO: derive(FromForm) so we don't need duplicate form structs
+// also, after the above refactoring, see if we can combine update and new
+// as they will most likely have the same fields when all features are impl'd
 #[derive(AsChangeset)]
 #[table_name = "users"]
 pub struct UpdateUser<'a> {

--- a/src/auth/models.rs
+++ b/src/auth/models.rs
@@ -25,7 +25,7 @@ pub struct User {
 }
 
 // TODO: derive(FromForm) so we don't need duplicate form structs
-#[derive(Insertable)]
+#[derive(Debug, Insertable)]
 #[table_name = "users"]
 pub struct NewUser<'a> {
     pub first_name: &'a str,
@@ -34,6 +34,14 @@ pub struct NewUser<'a> {
     pub password: &'a str,
 }
 
+#[derive(Debug, Insertable)]
+#[table_name = "users"]
+pub struct BulkNewUser {
+    pub first_name: String,
+    pub last_name: String,
+    pub email: String,
+    pub password: String,
+}
 
 // TODO: derive(FromForm) so we don't need duplicate form structs
 // also, after the above refactoring, see if we can combine update and new

--- a/src/bin/seed.rs
+++ b/src/bin/seed.rs
@@ -1,0 +1,85 @@
+extern crate bloglib;
+extern crate diesel;
+extern crate bcrypt;
+#[macro_use] extern crate fake;
+
+use bcrypt::{DEFAULT_COST, hash};
+use bloglib::*;
+use bloglib::posts::models::*;
+use bloglib::auth::models::*;
+use diesel::prelude::*;
+
+fn main() {
+    use bloglib::schema::posts::dsl::*;
+    use bloglib::schema::users::dsl::*;
+
+    let connection = create_db_pool().get().unwrap();
+    let plain_text_pw = "testing";
+    let hashed_password = match hash (plain_text_pw, DEFAULT_COST) {
+        Ok(hashed) => hashed,
+        Err(_) => panic!("Error hashing")
+    };
+
+
+    // Remove all users & posts from DB to start fresh
+    diesel::delete(posts).execute(&*connection).expect("Error deleteing posts");
+    diesel::delete(users).execute(&*connection).expect("Error deleteing users");
+
+    // Randomly generate user info
+    fn generate_user_info(pw: &str) -> BulkNewUser {
+        BulkNewUser {
+           first_name: fake!(Name.name),
+           last_name: fake!(Name.name),
+           email: fake!(Internet.free_email),
+           password: pw.to_string(),
+        }
+    }
+
+    // Randomly generate post info
+    fn generate_post_info(user: User) -> BulkNewPost {
+        let _title = &fake!(Lorem.sentence(1, 4))[..];
+        let _content = &fake!(Lorem.paragraph(5,5))[..];
+
+        BulkNewPost {
+           user_id: user.id,
+           title: _title.to_string(),
+           content: _content.to_string(),
+        }
+    }
+
+    // Create personal login
+    let me = NewUser {
+        first_name: "Ryan",
+        last_name: "Blecher",
+        email: "notryanb@gmail.com",
+        password: &hashed_password[..],
+    };
+    
+    diesel::insert(&me)
+        .into(users)
+        .execute(&*connection)
+        .expect("Error inserting users");
+
+    // Create 10 randomly generated users stored as a vec
+    let new_user_list: Vec<BulkNewUser> = (0..10)
+        .map( |_| generate_user_info(&hashed_password))
+        .collect();
+
+    // Insert that vec of users and get a vec back of the inserts
+    let returned_users = diesel::insert(&new_user_list)
+        .into(users)
+        .get_results::<User>(&*connection)
+        .expect("Error inserting users");
+
+    // For each of the new users, create some posts
+    let new_post_list: Vec<BulkNewPost> = returned_users
+        .into_iter()
+        .map(|user| generate_post_info(user))
+        .collect();
+
+    // Insert those posts
+    diesel::insert(&new_post_list)
+        .into(posts)
+        .execute(&*connection)
+        .expect("Error inserting posts");
+}

--- a/src/posts/forms.rs
+++ b/src/posts/forms.rs
@@ -1,6 +1,7 @@
 #[derive(FromForm)]
 pub struct UpdatePostForm {
     pub id: i32,
+    pub user_id: i32,
     pub title: String,
     pub content: String,
 }
@@ -19,6 +20,6 @@ pub struct DeletePostForm {
 #[derive(Serialize)]
 pub struct InvalidFormMessage<'a> {
     pub name: &'a str,
-    pub msg: &'a str
+    pub msg: &'a str,
 }
 

--- a/src/posts/forms.rs
+++ b/src/posts/forms.rs
@@ -15,3 +15,10 @@ pub struct CreatePostForm {
 pub struct DeletePostForm {
     pub id: i32,
 }
+
+#[derive(Serialize)]
+pub struct InvalidFormMessage<'a> {
+    pub name: &'a str,
+    pub msg: &'a str
+}
+

--- a/src/posts/mod.rs
+++ b/src/posts/mod.rs
@@ -34,7 +34,8 @@ fn index(user: User, conn: DbConn) -> Template {
 #[get("/show/<post_id>")]
 fn show(user: User, flash: Option<FlashMessage>, post_id: i32, conn: DbConn) -> Template {
     use super::schema::posts::dsl::*;
-
+    use super::schema::users::dsl::*;
+    
     let mut context = Context::new();
 
     if flash.is_some() {
@@ -46,6 +47,24 @@ fn show(user: User, flash: Option<FlashMessage>, post_id: i32, conn: DbConn) -> 
 
         context.add("flash", &message);
     }
+    
+    // TODO Joins User to display user info
+
+    let base_query = posts.find(post_id);
+    let post_with_user = base_query.inner_join(users)
+        .select(
+            (
+            title,
+            content,
+            published,
+            first_name,
+            last_name,
+            )
+        )
+        .load::<PostWithUser>(&*conn);
+
+    // TODO - use result and get all appropriate info for page
+    println!("Post w/ User: {:?}", post_with_user);
 
     let post = posts
         .find(post_id)

--- a/src/posts/models.rs
+++ b/src/posts/models.rs
@@ -5,7 +5,7 @@ use DbConn;
 use auth::models::User;
 use schema::posts;
 
-#[derive(Associations, Identifiable, Queryable, Serialize)]
+#[derive(Debug, Associations, Identifiable, Queryable, Serialize)]
 #[belongs_to(User)]
 pub struct Post {
     pub id: i32,
@@ -100,6 +100,14 @@ pub struct NewPost<'a> {
     pub user_id: i32,
     pub title: &'a str,
     pub content: &'a str,
+}
+
+#[derive(Insertable)]
+#[table_name = "posts"]
+pub struct BulkNewPost {
+    pub user_id: i32,
+    pub title: String,
+    pub content: String,
 }
 
 #[derive(AsChangeset)]

--- a/src/posts/models.rs
+++ b/src/posts/models.rs
@@ -50,7 +50,6 @@ impl PostWithAuthor {
     pub fn find(post_id: i32, conn: DbConn) -> PostWithAuthor {
         use diesel::prelude::*;
         use schema::posts::dsl::*;
-
         use schema::users;
         use schema::posts;
 
@@ -68,6 +67,29 @@ impl PostWithAuthor {
                 )
             )
             .first::<PostWithAuthor>(&*conn)
+            .expect("Error loading post")
+    }
+
+    pub fn load_all(conn: DbConn) -> Vec<PostWithAuthor> {
+        use diesel::prelude::*;
+        use schema::posts::dsl::*;
+        use schema::users;
+        use schema::posts;
+
+        posts.inner_join(users::table)
+            .select(
+                (
+                    posts::id,
+                    posts::user_id,
+                    posts::title,
+                    posts::content,
+                    posts::published,
+                    users::first_name,
+                    users::last_name,
+                )
+            )
+            .order(id.desc())
+            .get_results::<PostWithAuthor>(&*conn)
             .expect("Error loading post")
     }
 }

--- a/src/posts/models.rs
+++ b/src/posts/models.rs
@@ -1,3 +1,6 @@
+use serde::ser;
+use serde::ser::SerializeStruct;
+
 use auth::models::User;
 use schema::posts;
 
@@ -12,12 +15,36 @@ pub struct Post {
 }
 
 #[derive(Debug, Queryable)]
-pub struct PostWithUser{
+pub struct PostWithAuthor{
+    pub id: i32,
+    pub user_id: i32,
     pub title: String,
     pub content: String,
     pub published: bool,
     pub first_name: String,
     pub last_name: String,
+}
+
+impl ser::Serialize for PostWithAuthor {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        let mut s = serializer.serialize_struct("PostWithAuthor", 6)?;
+        s.serialize_field("id", &self.id)?;
+        s.serialize_field("user_id", &self.id)?;
+        s.serialize_field("title", &self.title)?;
+        s.serialize_field("content", &self.content)?;
+        s.serialize_field("published", &self.published)?;
+        s.serialize_field("display_name", &self.display_name())?;
+        s.end()
+    }
+}
+
+impl PostWithAuthor {
+    pub fn display_name(&self) -> String {
+        format!("{} {}", self.first_name, self.last_name)
+    }
 }
 
 #[derive(Insertable)]

--- a/src/posts/models.rs
+++ b/src/posts/models.rs
@@ -11,6 +11,15 @@ pub struct Post {
     pub published: bool,
 }
 
+#[derive(Debug, Queryable)]
+pub struct PostWithUser{
+    pub title: String,
+    pub content: String,
+    pub published: bool,
+    pub first_name: String,
+    pub last_name: String,
+}
+
 #[derive(Insertable)]
 #[table_name = "posts"]
 pub struct NewPost<'a> {

--- a/templates/auth/login.html.tera
+++ b/templates/auth/login.html.tera
@@ -2,9 +2,14 @@
 
 {% block main %}
     <h1>Login</h1>
+    <div>
+        <a href="/auth/register">Register</a>
+    </div>
+
     {% if flash %}
-      <div class="flash-err">{{ flash.name}} - {{ flash.msg }}</div>
+        <div class="flash-err">{{ flash.name }} - {{ flash.msg }} </div>
     {% endif %}
+
     <form id="login" method="post" action="/auth/login">
         <input name="email" type="text" placeholder="email" required>
         <input name="password" type="password" placeholder="password" required>

--- a/templates/auth/register.html.tera
+++ b/templates/auth/register.html.tera
@@ -1,0 +1,13 @@
+{% extends "main" %}
+
+{% block main %}
+    <h1>Register</h1>
+    {% block flash %}{% endblock flash %}
+    <form id="register" method="post" action="/auth/register">
+        <input name="email" type="text" placeholder="email" required>
+        <input name="password" type="password" placeholder="password" required>
+        <input name="password_confirm" type="password" placeholder="password confirm" required>
+        <button type="submit">Register</button>
+    </form>
+{% endblock main %}
+

--- a/templates/auth/register.html.tera
+++ b/templates/auth/register.html.tera
@@ -2,8 +2,14 @@
 
 {% block main %}
     <h1>Register</h1>
-    {% block flash %}{% endblock flash %}
+
+    {% if flash %}
+        <div class="flash-err">{{ flash.name }} - {{ flash.msg }} </div>
+    {% endif %}
+
     <form id="register" method="post" action="/auth/register">
+        <input name="first_name" type="text" placeholder="first name" required>
+        <input name="last_name" type="text" placeholder="last name" required>
         <input name="email" type="text" placeholder="email" required>
         <input name="password" type="password" placeholder="password" required>
         <input name="password_confirm" type="password" placeholder="password confirm" required>

--- a/templates/auth/register.html.tera
+++ b/templates/auth/register.html.tera
@@ -7,7 +7,7 @@
         <div class="flash-err">{{ flash.name }} - {{ flash.msg }} </div>
     {% endif %}
 
-    <form id="register" method="post" action="/auth/register">
+    <form id="register" method="POST" action="/auth/register">
         <input name="first_name" type="text" placeholder="first name" required>
         <input name="last_name" type="text" placeholder="last name" required>
         <input name="email" type="text" placeholder="email" required>

--- a/templates/auth/settings.html.tera
+++ b/templates/auth/settings.html.tera
@@ -1,0 +1,20 @@
+{% extends "main" %}
+
+{% block main %}
+    <h1>Edit User Settings</h1>
+
+    {% if flash %}
+        <div class="flash-err">{{ flash.name }} - {{ flash.msg }} </div>
+    {% endif %}
+
+    <form id="user_settings" method="POST" action="/auth/settings">
+        <input name="id" type="hidden" value={{ user.id }}>
+        <input name="first_name" type="text" placeholder="first name" value={{ user.first_name }}>
+        <input name="last_name" type="text" placeholder="last name" value={{ user.last_name }}>
+        <input name="email" type="text" placeholder="email" value={{ user.email }}>
+        <input name="password" type="password" placeholder="password" required>
+        <input name="password_confirm" type="password" placeholder="password confirm" required>
+        <button type="submit">Register</button>
+    </form>
+{% endblock main %}
+

--- a/templates/main.html.tera
+++ b/templates/main.html.tera
@@ -13,6 +13,7 @@
                     <a href="/auth/login">> Login</a>
                 {% else %}
                     <a href="/posts/new">> Create Post</a>
+                    <a href="/auth/settings">> User Settings</a>
                     <a href="/auth/logout">> Logout</a>
                 {% endif %}
               </nav>

--- a/templates/posts/edit.html.tera
+++ b/templates/posts/edit.html.tera
@@ -4,6 +4,7 @@
     <h1>Edit a Post</h1>
     <form id="edit-post" method="post" action="/posts/update">
         <input name="id" type="hidden" value="{{ post.id }}" required>
+        <input name="user_id" type="hidden" value="{{ post.user_id }}" required>
         <input name="title" type="text" placeholder="{{ post.title }}" required>
         <textarea name="content" rows=10 columns = 50 placeholder="{{ post.content }}" required></textarea>
         <button type="submit">Submit Post</button>

--- a/templates/posts/index.html.tera
+++ b/templates/posts/index.html.tera
@@ -5,7 +5,7 @@
         <h1>Rust Blog</h1>
         {% for post in posts %}
             <div class="post-item">
-              <span><a href="/posts/show/{{ post.id }}">{{ post.title }}</a></span>
+              <span><a href="/posts/show/{{ post.id }}">{{ post.title }}</a> - by {{ post.display_name }}</span>
             </div>
         {% endfor %}
     </article>

--- a/templates/posts/show.html.tera
+++ b/templates/posts/show.html.tera
@@ -4,9 +4,14 @@
   {% if user is defined %}
     {% if user.is_anonymous %}
     {% else %}
+      {% if user.id == post.user_id %}
         <a href="/posts/edit/{{ post.id }}">Edit</a>
         <a href="/posts/delete/{{ post.id }}">Delete</a>
+      {% endif %}
     {% endif %}
+  {% endif %}
+  {% if flash %}
+      <div class="flash-err">{{ flash.name }} - {{ flash.msg }} </div>
   {% endif %}
   <article class="post">
     <h2>{{ post.title }}</h2>

--- a/templates/posts/show.html.tera
+++ b/templates/posts/show.html.tera
@@ -14,7 +14,7 @@
       <div class="flash-err">{{ flash.name }} - {{ flash.msg }} </div>
   {% endif %}
   <article class="post">
-    <h2>{{ post.title }}</h2>
+    <h2>{{ post.title }} by {{ post.display_name }}</h2>
     <p>{{ post.content }}</p>
   </article>
 {% endblock main %}


### PR DESCRIPTION
Add basic user registration. Implemented sloppily for diesel v0.16, as the next branch should take this feature and upgrade the diesel dependency to v1.1.1.

Can update all user settings once logged in. Redirects based on auth state with flash errors. Now offers seeding procedure

Fixes #17 
Fixes #18 
Fixes #20 
